### PR TITLE
Remove useless cast type.

### DIFF
--- a/07-read-write-file.go
+++ b/07-read-write-file.go
@@ -32,10 +32,10 @@ func main() {
 	// so must cast to string first and then can display
 	fmt.Println(string(content))
 
-	// write back to new file, need to cast back to []byte
+	// write back to new file
 	// see documentation for which methods take what type
 	outfile := "output.txt"
-	err = ioutil.WriteFile(outfile, []byte(content), 0644)
+	err = ioutil.WriteFile(outfile, content, 0644)
 	if err != nil {
 		log.Fatalln("Error writing file: ", err)
 	}


### PR DESCRIPTION
`content`'s type is already `[]byte`, no need to cast.
